### PR TITLE
Updates generic lowerBound, upperBound, and binarySearch to use binary predicate

### DIFF
--- a/binarysearch.swift
+++ b/binarysearch.swift
@@ -70,14 +70,15 @@ extension CollectionType {
     /// - Returns: An index such that each element at or above the returned
     ///            index evaluates `false` with respect to `isOrderedBelow(_:)`
     @warn_unused_result
-    func lowerBound(@noescape isOrderedBefore: Self.Generator.Element -> Bool) 
-    -> Index {
+    func lowerBound(value: Self.Generator.Element,
+        @noescape isOrderedBefore: (Self.Generator.Element,
+                                    Self.Generator.Element -> Bool) -> Index {
         var len = self.startIndex.distanceTo(self.endIndex)
         var firstIndex = self.startIndex
         while len > 0 {
             let half = len/2
             let middle = firstIndex.advanceBy(half)
-            if isOrderedBelow(self[middle]) {
+            if isOrderedBelow(self[middle], value) {
                 firstIndex = middle.advanceBy(1)
                 len -= half + 1
             } else {
@@ -90,24 +91,25 @@ extension CollectionType {
     /// Returns an index such that each element above the index is strictly
     /// greater than the partitioning element.
     ///
-    /// - Parameter isOrderedAfter: The partitioning predicate. Returns `true`
-    ///                             for elements that are strictly greater
-    ///                             than the partitioning value and `false`
-    ///                             otherwise.
+    /// - Parameter isOrderedBelow: The partitioning predicate. Returns `true`
+    ///                             for elements that are ordered below with
+    ///                             respect to the partitioning element and
+    ///                             `false` otherwise.
     ///
     /// - Complexity: O(lg(n))
     ///
     /// - Returns: An index such that each element above the index evaluates
-    ///            `true` with respect to `isOrderedAfter(_:)`
+    ///            `true` with respect to `isOrderedBefore(_:)`
     @warn_unused_result
-    func upperBound(@noescape isOrderedAfter: Self.Generator.Element -> Bool)
-    -> Index {
+    func upperBound(value: Self.Generator.Element,
+        @noescape isOrderedBefore: (Self.Generator.Element, 
+                                    Self.Generator.Element) -> Bool) -> Index {
         var len = self.startIndex.distanceTo(self.endIndex)
         var firstIndex = self.startIndex
         while len > 0 {
             let half = len/2
             let middle = firstIndex.advanceBy(half)
-            if isOrderedAfter(self[middle]) {
+            if isOrderedBefore(value, self[middle]) {
                 len = half
             } else {
                 firstIndex = middle.advanceBy(1)
@@ -117,17 +119,17 @@ extension CollectionType {
         return firstIndex
     }
 
-    // TODO: This does not currently work as expected.
     /// Returns `true` if element is in the collection and `false` otherwise.
     ///
     /// - Parameter isOrderedBefore: The partitioning predicate. INCOMPLETE
     ///
     /// - Complexity: O(lg(n))
     @warn_unused_result
-    func binarySearch(@noescape isOrderedBefore: Self.Generator.Element -> Bool)
-    -> Bool {
+    func binarySearch(value: Self.Generator.Element,
+        @noescape isOrderedBefore: (Self.Generator.Element, 
+                                    Self.Generator.Element) -> Bool) -> Bool {
         let lowerBound = lowerBound(isOrderedBefore)
         return (lowerBound != self.endIndex) && 
-                !isOrderedBefore(self[lowerBound])
+               !isOrderedBefore(value, self[lowerBound])
     }
 }

--- a/binarysearch.swift
+++ b/binarysearch.swift
@@ -37,6 +37,19 @@ extension CollectionType where Generator.Element : Comparable {
         }
         return firstIndex
     }
+
+    /// Returns `true` if the collection contains `value` and
+    /// `false` otherwise.
+    ///
+    /// - Complexity: O(lg(n))
+    ///
+    /// - Returns: `true` if the collection contains `value`
+    ///            and `false` otherwise.
+    @warn_unused_result
+    func binarySearch(value: Self.Generater.Element) -> Index {
+        let lowerBound = lowerBound(value)
+        return (lowerBound != self.endIndex) && !(value < lowerBound)
+    }
 }
 
 


### PR DESCRIPTION
Per our discussions, I updated the implementations for `lowerBound`, `upperBound`, and `binarySearch` to take a `value` and a binary predicate `isOrderedBefore`. I also added `equalRange` for collections adhering to the `Comparable` protocol.
