### PR TITLE
Add equalRange method

### DIFF
--- a/binarysearch.swift
+++ b/binarysearch.swift
@@ -1,10 +1,11 @@
 extension CollectionType where Generator.Element : Comparable {
     
-    ///Returns the index of the first element in the collection which does not compare less than `value`.
+    /// Returns the index of the first element in the collection which does not
+    /// compare less than `value`.
     @warn_unused_result
-    func lowerBound(value: Self.Generator.Element) -> Index {
-        var len = self.startIndex.distanceTo(self.endIndex)
-        var firstIndex = self.startIndex
+    public func lowerBound(value: Self.Generator.Element) -> Index {
+        var len = count
+        var firstIndex = startIndex
         while len > 0 {
             let half = len/2
             let middle = firstIndex.advancedBy(half)
@@ -19,11 +20,12 @@ extension CollectionType where Generator.Element : Comparable {
         return firstIndex
     }
     
-    ///Returns the index of the first element in the collection which compares greater than `value`.
+    /// Returns the index of the first element in the collection which compares 
+    /// greater than `value`.
     @warn_unused_result
-    func upperBound(value: Self.Generator.Element) -> Index {
-        var len = self.startIndex.distanceTo(self.endIndex)
-        var firstIndex = self.startIndex
+    public func upperBound(value: Self.Generator.Element) -> Index {
+        var len = count
+        var firstIndex = startIndex
         while len > 0 {
             let half = len/2
             let middle = firstIndex.advancedBy(half)
@@ -46,9 +48,13 @@ extension CollectionType where Generator.Element : Comparable {
     /// - Returns: `true` if the collection contains `value`
     ///            and `false` otherwise.
     @warn_unused_result
-    func binarySearch(value: Self.Generater.Element) -> Index {
-        let lowerBound = lowerBound(value)
-        return (lowerBound != self.endIndex) && !(value < lowerBound)
+    public func binarySearch(value: Self.Generator.Element) -> Index? {
+        let i = lowerBound(value)
+        if (i != endIndex) && !(value < self[i]) {
+            return i
+        } else {
+            return nil
+        }
     }
 }
 
@@ -70,16 +76,16 @@ extension CollectionType {
     /// - Returns: An index such that each element at or above the returned
     ///            index evaluates `false` with respect to `isOrderedBelow(_:)`
     @warn_unused_result
-    func lowerBound(value: Self.Generator.Element,
+    public func lowerBound(value: Self.Generator.Element,
         @noescape isOrderedBefore: (Self.Generator.Element,
-                                    Self.Generator.Element -> Bool) -> Index {
-        var len = self.startIndex.distanceTo(self.endIndex)
-        var firstIndex = self.startIndex
+                                    Self.Generator.Element) -> Bool) -> Index {
+        var len = startIndex.distanceTo(endIndex)
+        var firstIndex = startIndex
         while len > 0 {
             let half = len/2
-            let middle = firstIndex.advanceBy(half)
-            if isOrderedBelow(self[middle], value) {
-                firstIndex = middle.advanceBy(1)
+            let middle = firstIndex.advancedBy(half)
+            if isOrderedBefore(self[middle], value) {
+                firstIndex = middle.advancedBy(1)
                 len -= half + 1
             } else {
                 len = half
@@ -101,18 +107,18 @@ extension CollectionType {
     /// - Returns: An index such that each element above the index evaluates
     ///            `true` with respect to `isOrderedBefore(_:)`
     @warn_unused_result
-    func upperBound(value: Self.Generator.Element,
+    public func upperBound(value: Self.Generator.Element,
         @noescape isOrderedBefore: (Self.Generator.Element, 
                                     Self.Generator.Element) -> Bool) -> Index {
-        var len = self.startIndex.distanceTo(self.endIndex)
-        var firstIndex = self.startIndex
+        var len = startIndex.distanceTo(endIndex)
+        var firstIndex = startIndex
         while len > 0 {
             let half = len/2
-            let middle = firstIndex.advanceBy(half)
+            let middle = firstIndex.advancedBy(half)
             if isOrderedBefore(value, self[middle]) {
                 len = half
             } else {
-                firstIndex = middle.advanceBy(1)
+                firstIndex = middle.advancedBy(1)
                 len -= half + 1
             }
         }
@@ -125,11 +131,14 @@ extension CollectionType {
     ///
     /// - Complexity: O(lg(n))
     @warn_unused_result
-    func binarySearch(value: Self.Generator.Element,
+    public func binarySearch(value: Self.Generator.Element,
         @noescape isOrderedBefore: (Self.Generator.Element, 
-                                    Self.Generator.Element) -> Bool) -> Bool {
-        let lowerBound = lowerBound(isOrderedBefore)
-        return (lowerBound != self.endIndex) && 
-               !isOrderedBefore(value, self[lowerBound])
+                                    Self.Generator.Element) -> Bool) -> Index? {
+        let i = lowerBound(value, isOrderedBefore: isOrderedBefore)
+        if (i != endIndex) && !isOrderedBefore(value, self[i]) {
+            return i
+        } else {
+            return nil
+        }
     }
 }


### PR DESCRIPTION
This adds the two variations of the `equalRange` method and fixes a few issues with the existing code. The methods are now marked `public`, so you can drop this in a Playground's Sources directory and test the methods there.

The extension constraints for the `equalRange` method are ugly because it calls the other methods on its subsequences—those extra bits are essentially the definition of a subsequence, but the compiler can't require them without all that extra stuff.

I don't particularly like the `equalRange` name—I know it's what C++ calls that algorithm but it doesn't describe it very well. What do you all think of `range(of:)` or `bounds(of:)` to match `lower/upperBound`?
