### PR TITLE
Revise proposal to describe new APIs

### DIFF
--- a/SE-0047.md
+++ b/SE-0047.md
@@ -115,7 +115,7 @@ extension Collection {
         ) rethrows -> Range<Index>
 }
 
-extension Collection where Generator.Element: Comparable {}
+extension Collection where Generator.Element: Comparable {
     /// Returns the index of `element`, performing a binary search.
     ///
     /// The elements of the collection must already be sorted, or at
@@ -123,10 +123,7 @@ extension Collection where Generator.Element: Comparable {}
     ///
     /// - Returns: The index of `element`, or `nil` if `element` isn't
     ///   found.
-    func sortedIndex(of element: Generator.Element,
-        @noescape isOrderedBefore: (Generator.Element, Generator.Element)
-            throws -> Bool
-        ) rethrows -> Index?
+    func sortedIndex(of element: Generator.Element) -> Index?
 
     /// Returns the range of elements equal to `element`, performing
     /// a binary search.
@@ -137,10 +134,7 @@ extension Collection where Generator.Element: Comparable {}
     /// - Returns: The range of indices corresponding with elements
     ///   equal to `element`, or an empty range with its `startIndex`
     ///   equal to the insertion point for `element`.
-    func sortedRange(of element: Generator.Element,
-        @noescape isOrderedBefore: (Generator.Element, Generator.Element)
-            throws -> Bool
-        ) rethrows -> Range<Index>
+    func sortedRange(of element: Generator.Element) -> Range<Index>
 }
 ```
 

--- a/SE-0047.md
+++ b/SE-0047.md
@@ -7,121 +7,153 @@
 
 ## Introduction
 
-Swift does not offer any binary search implementation.
-This proposal seeks to add few different functions that implement the binary search algorithm.
+Swift does not offer any way to efficiently search sorted collections.
+This proposal seeks to add a few different functions that implement the binary search algorithm.
 
-Swift-evolution thread: [[swift-evolution] [Proposal] Add Binary Search functions to	SequenceType](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160314/012680.html)
-
-JIRA: [Swift/SR-368](https://bugs.swift.org/browse/SR-368)
+- Swift-evolution thread: [[swift-evolution] [Proposal] Add Binary Search functions to SequenceType](https://lists.swift.org/pipermail/swift-evolution/Week-of-Mon-20160314/012680.html)
+- JIRA: [Swift/SR-368](https://bugs.swift.org/browse/SR-368)
 
 ## Motivation
 
-Searching through wide arrays (more than 100k elements) is inherently inefficient as the existing `SequenceType.contains( element:)` performs a linear search that has to test the given condition for every element of the array.
+Searching through wide arrays (more than 100k elements) is inherently inefficient as the existing `SequenceType.contains(_:)` performs a linear search that has to test the given condition for every element of the array.
 
-Sorting the array would typically improve the efficiency of this search from O(n) to O(log n) by allowing a binary search algorithm that always cuts the search space in half. Unfortunately, the standard library has no built-in ability to search on a collection that is known to be sorted.
+Storing data in a sorted array would typically improve the efficiency of this search from O(n) to O(log n) by allowing a binary search algorithm that cuts the search space in half with each iteration. Unfortunately, the standard library has no built-in ability to search on a collection that is known to be sorted.
 
 ## Proposed solution
 
-The solution is adding four new functions that implement binary search, present in many other programming languages, called `binarySearch`, `lowerBound`, `upperBound`, and `equalRange`. They would be added to any type using `CollectionType`.
+The proposed solution is to add three new methods that implement the binary search algorithm, called `partitionedIndex(where:)`, `sortedIndex(of:)`, and `sortedRange(of:)`, as well as a partitioning method called `partition(where:)`. These methods would be added to any type using `CollectionType`.
 
-The following array will be used in the examples below:
+In addition, this proposal suggests the removal of the two existing `partition()` methods from public API, as they are implementation details of the current `sort()` algorithm and not as generally useful as the proposed `partition(where:)` method.
+
+The following arrays will be used in the examples below:
 
     let a = [10, 20, 30, 30, 30, 40, 60]
+    let r = [60, 40, 30, 30, 30, 20, 10]  // i.e., a.reversed()
 
-- `binarySearch` implements a binary search algorithm that finds the position of a given value. For example: 
+- `partitionedIndex(where:)` accepts a unary predicate and returns the index of the first value in the collection that does not satisfy the predicate. The elements of the collection must already be partitioned by the predicate. This method corresponds with `partition_point` in the C++11 STL.
 
-        a.binarySearch(20)      // 1
-        a.binarySearch(30)      // 2
-        a.binarySearch(50)      // nil
-  
-- `lowerBound` finds the position of the first element not less than a given value. If the value isn't found, the returned index is its lower insertion point.
+        a.partitionedIndex(where: { $0 < 20 })      // 1
 
-        a.lowerBound(30)        // 2
-        a.lowerBound(50)        // 6
-        a.lowerBound(100)       // 7
+    If you have a binary (two-argument) predicate, like `<`, you can construct unary predicates for `partitionedIndex(where:)` that find the lower and upper bound for a given value:
 
-- `upperBound` finds the position of the first element greater than a given value. If the value isn't found, the returned index is its upper insertion point.
+        a.partitionedIndex(where: { $0 < 30 })      // 2 - lower bound
+        a.partitionedIndex(where: { !(30 < $0) })   // 5 - upper bound
 
-        a.upperBound(30)        // 5
-        a.upperBound(50)        // 6
-        a.upperBound(100)       // 7
+- `sortedIndex(of:)` finds the position of a given value in a sorted collection. If the value isn't found, the method returns `nil`. An additional version of the method takes a value and a binary `isOrderedBefore` closure. This method loosely corresponds with `binary_search` in the C++ STL, but returns the value's index if found, rather than just `true`.
 
-- `equalRange` finds the range of all consecutive elements that are equivalent to a given value. If the value isn't found, the range is empty with `lowerBound(value)` as its `startIndex`.
+        a.sortedIndex(of: 30)        // 2
+        a.sortedIndex(of: 60)        // 6
+        a.sortedIndex(of: 100)       // nil
+        r.sortedIndex(of: 60, isOrderedBefore: >)  // 0
 
-        a.equalRange(30)        // 2..<5
-        a.equalRange(50)        // 6..<6
+- `sortedRange(of:)` finds the range of all consecutive elements that are equivalent to a given value. If the value isn't found, the range is empty with `lowerBound(value)` as its `startIndex`. An additional version of the method takes a value and a binary `isOrderedBefore` closure. This method corresponds with `equal_range` in the C++ STL.
+
+        a.sortedRange(of: 30)        // 2..<5
+        a.sortedRange(of: 50)        // 6..<6
+
+- `partition(where:)` is a mutating method that accepts a unary (one-argument) predicate. The elements of the collection are partitioned according to the predicate, so that there is a pivot index `p` where every element before `p` matches the predicate and every element at and after `p` doesn't match the predicate. This method corresponds with `partition` in the C++ STL.
+
+        var n = [30, 40, 20, 30, 30, 60, 10]
+        let p = n.partition(where: { $0 < 30 })
+        // n == [30, 20, 30, 30, 10, 40, 60]
+        // p == 5
+
+    After partitioning, the predicate returns `true` for every element in `n.prefix(upTo: p)` and `false` for every element in `n.suffix(from: p)`.
 
 ## Detailed design
 
-**1.** `binarySearch` exists in two versions: it accepts either the value of a `value` to be searched for, or a predicate `isOrderedBefore` to be satisfied. 
+The proposed APIs are collected here:
 
-The function returns `nil` if not any are found.
+```swift
+extension Collection {
+    /// Reorders the elements of the collection such that all the
+    /// elements that match the predicate are ordered before all the
+    /// elements that do not match the predicate.
+    ///
+    /// - Returns: The index of the first element in the reordered
+    ///   collection that does not match the predicate.
+    mutating func partition(
+        @noescape where predicate: (Generator.Element) throws-> Bool
+        ) rethrows -> Index
 
+    /// Returns the index of the first element in the collection
+    /// that doesn't match the predicate.
+    ///
+    /// The collection must already be partitioned according to the
+    /// predicate, as if `x.partition(where: predicate)` had already
+    /// been called.
+    func partitionedIndex(
+        @noescape where predicate: (Generator.Element) throws -> Bool
+        ) rethrows -> Index
 
-**2.** `lowerBound` exists in two versions: it accepts either the value of a `value` to be searched for, or a predicate `isOrderedBefore` to be satisfied. 
+    /// Returns the index of `element`, using `isOrderedBefore` as the
+    /// comparison predicate while performing a binary search.
+    ///
+    /// The elements of the collection must already be sorted according
+    /// to `isOrderedBefore`, or at least partitioned by `element`.
+    ///
+    /// - Returns: The index of `element`, or `nil` if `element` isn't
+    ///   found.
+    func sortedIndex(of element: Generator.Element,
+        @noescape isOrderedBefore: (Generator.Element, Generator.Element)
+            throws -> Bool
+        ) rethrows -> Index?
 
-Note that the first one is defined when the elements of the collection are `Comparable`, as specified in the code.
+    /// Returns the range of elements equivalent to `element`, using
+    /// `isOrderedBefore` as the comparison predicate while performing
+    /// a binary search.
+    ///
+    /// The elements of the collection must already be sorted according
+    /// to `isOrderedBefore`, or at least partitioned by `element`.
+    ///
+    /// - Returns: The range of indices corresponding with elements
+    ///   equivalent to `element`, or an empty range with its
+    ///   `startIndex` equal to the insertion point for `element`.
+    func sortedRange(of element: Generator.Element,
+        @noescape isOrderedBefore: (Generator.Element, Generator.Element)
+            throws -> Bool
+        ) rethrows -> Range<Index>
+}
 
-The first version is defined as here:
+extension Collection where Generator.Element: Comparable {}
+    /// Returns the index of `element`, performing a binary search.
+    ///
+    /// The elements of the collection must already be sorted, or at
+    /// least partitioned by `element`.
+    ///
+    /// - Returns: The index of `element`, or `nil` if `element` isn't
+    ///   found.
+    func sortedIndex(of element: Generator.Element,
+        @noescape isOrderedBefore: (Generator.Element, Generator.Element)
+            throws -> Bool
+        ) rethrows -> Index?
 
-    ///Returns the index of the first element in the collection which does not compare less than `value`.
-    extension CollectionType where Generator.Element : Comparable {
-    @warn_unused_result
-    func lowerBound(value: Self.Generator.Element) -> Index {
-        var len = self.startIndex.distanceTo(self.endIndex)
-        var firstIndex = self.startIndex
-        while len > 0 {
-            let half = len/2
-            let middle = firstIndex.advancedBy(half)
-            
-            if value > self[middle] {
-                firstIndex = middle.advancedBy(1)
-                len -= half.successor()
-            } else {
-                len = half
-            }
-        }
-        return firstIndex
-      }
-    }
-
-The second one is :
-
-**3.** `upperBound` exists in two versions: it accepts either the value of a `value` to be searched for, or a predicate `isOrderedAfter` to be satisfied. 
-
-Note that the first one is defined when the elements of the collection are `Comparable`, as specified in the code.
-
-The first version is defined as here:
-
-    ///Returns the index of the first element in the collection which compares greater than `value`.
-    extension CollectionType where Generator.Element : Comparable {
-    @warn_unused_result
-    func upperBound(value: Self.Generator.Element) -> Index {
-        var len = self.startIndex.distanceTo(self.endIndex)
-        var firstIndex = self.startIndex
-        while len > 0 {
-            let half = len/2
-            let middle = firstIndex.advancedBy(half)
-            
-            if value < self[middle] {
-                len = half
-            } else {
-                firstIndex = middle.advancedBy(1)
-                len -= half.successor()
-            }
-        }
-        return firstIndex
-      }
-    }
-    
-The second one is:
+    /// Returns the range of elements equal to `element`, performing
+    /// a binary search.
+    ///
+    /// The elements of the collection must already be sorted, or at
+    /// least partitioned by `element`.
+    ///
+    /// - Returns: The range of indices corresponding with elements
+    ///   equal to `element`, or an empty range with its `startIndex`
+    ///   equal to the insertion point for `element`.
+    func sortedRange(of element: Generator.Element,
+        @noescape isOrderedBefore: (Generator.Element, Generator.Element)
+            throws -> Bool
+        ) rethrows -> Range<Index>
+}
+```
 
 ## Impact on existing code
 
-The only change on code will be the availability of four (plus overloads) safer functions implementing Binary Search. 
+The only change on code will be the availability of four (plus overloads) safer functions implementing partitioning and binary search.
 
 Given the notorious difficulty for a programmer to implement binary search on their own, this proposal aims to simplify its use and thus reduce the amount of bugs in programs.
 
 ## Alternatives considered
 
-The only alternative at this time is "no change" to the library.
+The authors considered a few alternatives to the current proposal:
+
+- `lower_bound` / `upper_bound`: The C++ STL includes two functions that help when searching sorted collections and when sorting or merging. However, both are subsumed by the functionality of `partition_point` and its unary predicate, and as such are not needed. Whether these methods should accept unary or binary predicates was also a matter of discussion.
+
+- `binary_search`: The STL function analogous to the proposed `sortedIndex(of:)` method returns only a Boolean value. We determined that a method returning an optional index was more useful: the `.none` case conveys "not found", and the returned index (when found) provides easy access to the matched element.


### PR DESCRIPTION
This is a big revision to the proposal that describes the APIs discussed in #5 in detail. The names are still totally up in the air, but I've used my suggestions:
- `sortedIndex(of:)` instead of `binarySearch`
- `sortedRange(of:)` instead of `equalRange`
- `partitionedIndex(where:)` instead of `partitionPoint`
- `partition(where:)` for the mutating method

I think these have internal consistency and comport well with existing methods of the Swift 3 standard library, most notably `index(of:)` and `index(where:)`. What do you think? I think there's some danger in users thinking that a method like `sortedIndex(of:)` sorts the collection before finding the index, but I'm not sure of how else to distinguish these methods from the standard `index(of:)`.
