### PR TITLE
Fix syntax, add more stuff

### DIFF
--- a/SE-0047.md
+++ b/SE-0047.md
@@ -118,11 +118,6 @@ extension Collection {
         @noescape isOrderedBefore: (Iterator.Element, Iterator.Element)
             throws -> Bool
         ) rethrows -> Range<Index>
-        
-    /// Returns `Optional(Optional(index))` if an element was found;
-    /// `Optional(nil)` if an element was searched for but not found;
-    /// `nil` otherwise.
-    func _customIndexOfComparableElement(element: Iterator.Element) -> Index??
 }
 
 extension Collection where Iterator.Element: Comparable {
@@ -146,12 +141,39 @@ extension Collection where Iterator.Element: Comparable {
     ///   equal to the insertion point for `element`.
     func sortedRange(of element: Iterator.Element) -> Range<Index>
 }
+```
 
-extension Sequence {
+The customization points will need to be added to the protocol declarations for `Sequence` and `Collection`, with default implementations that simply return `nil`.
+
+```swift
+protocol Sequence {
+    // existing Sequence declarations...
+    
     /// Returns `Optional(true)` if an element was found;
     /// `Optional(false)` if an element was searched for but not found;
     /// `nil` otherwise.
     func _customContainsComparableElement(element: Iterator.Element) -> Bool?
+}
+
+extension Sequence {
+    func _customContainsComparableElement(element: Iterator.Element) -> Bool? { 
+        return nil
+    }
+}
+
+protocol Collection {
+    // existing Collection declarations...
+            
+    /// Returns `Optional(Optional(index))` if an element was found;
+    /// `Optional(nil)` if an element was searched for but not found;
+    /// `nil` otherwise.
+    func _customIndexOfComparableElement(element: Iterator.Element) -> Index??
+}
+
+extension Collection {
+    func _customIndexOfComparableElement(element: Iterator.Element) -> Index?? {
+        return nil
+    }
 }
 ```
 

--- a/SE-0047.md
+++ b/SE-0047.md
@@ -21,9 +21,11 @@ Storing data in a sorted array would typically improve the efficiency of this se
 
 ## Proposed solution
 
-The proposed solution is to add three new methods that implement the binary search algorithm, called `partitionedIndex(where:)`, `sortedIndex(of:)`, and `sortedRange(of:)`, as well as a partitioning method called `partition(where:)`. These methods would be added to any type using `CollectionType`.
+The proposed solution is to add three new methods that implement the binary search algorithm, called `partitionedIndex(where:)`, `sortedIndex(of:)`, and `sortedRange(of:)`, as well as a partitioning method called `partition(where:)`. These methods would be added to the `Collection` protocol as default implementations.
 
-In addition, this proposal suggests the removal of the two existing `partition()` methods from public API, as they are implementation details of the current `sort()` algorithm and not as generally useful as the proposed `partition(where:)` method.
+To support future sorted collections, this proposal also suggests the addition of customization points for `contains(_:)` and `index(of:)` for collections with `Comparable` elements: `Sequence._customContainsComparableElement(_:)` and `Collection._customIndexOfComparableElement(_:)`.
+
+Finally, this proposal suggests the removal of the two existing `partition()` methods from public API, as they are implementation details of the current `sort()` algorithm and not as generally useful as the proposed `partition(where:)` method.
 
 The following arrays will be used in the examples below:
 
@@ -65,17 +67,20 @@ The following arrays will be used in the examples below:
 The proposed APIs are collected here:
 
 ```swift
-extension Collection {
+extension MutableCollection {
     /// Reorders the elements of the collection such that all the
     /// elements that match the predicate are ordered before all the
     /// elements that do not match the predicate.
     ///
     /// - Returns: The index of the first element in the reordered
     ///   collection that does not match the predicate.
+    @discardableResult
     mutating func partition(
-        @noescape where predicate: (Generator.Element) throws-> Bool
+        @noescape where predicate: (Iterator.Element) throws-> Bool
         ) rethrows -> Index
+}
 
+extension Collection {
     /// Returns the index of the first element in the collection
     /// that doesn't match the predicate.
     ///
@@ -83,7 +88,7 @@ extension Collection {
     /// predicate, as if `x.partition(where: predicate)` had already
     /// been called.
     func partitionedIndex(
-        @noescape where predicate: (Generator.Element) throws -> Bool
+        @noescape where predicate: (Iterator.Element) throws -> Bool
         ) rethrows -> Index
 
     /// Returns the index of `element`, using `isOrderedBefore` as the
@@ -94,8 +99,8 @@ extension Collection {
     ///
     /// - Returns: The index of `element`, or `nil` if `element` isn't
     ///   found.
-    func sortedIndex(of element: Generator.Element,
-        @noescape isOrderedBefore: (Generator.Element, Generator.Element)
+    func sortedIndex(of element: Iterator.Element,
+        @noescape isOrderedBefore: (Iterator.Element, Iterator.Element)
             throws -> Bool
         ) rethrows -> Index?
 
@@ -109,13 +114,18 @@ extension Collection {
     /// - Returns: The range of indices corresponding with elements
     ///   equivalent to `element`, or an empty range with its
     ///   `startIndex` equal to the insertion point for `element`.
-    func sortedRange(of element: Generator.Element,
-        @noescape isOrderedBefore: (Generator.Element, Generator.Element)
+    func sortedRange(of element: Iterator.Element,
+        @noescape isOrderedBefore: (Iterator.Element, Iterator.Element)
             throws -> Bool
         ) rethrows -> Range<Index>
+        
+    /// Returns `Optional(Optional(index))` if an element was found;
+    /// `Optional(nil)` if an element was searched for but not found;
+    /// `nil` otherwise.
+    func _customIndexOfComparableElement(element: Iterator.Element) -> Index??
 }
 
-extension Collection where Generator.Element: Comparable {
+extension Collection where Iterator.Element: Comparable {
     /// Returns the index of `element`, performing a binary search.
     ///
     /// The elements of the collection must already be sorted, or at
@@ -123,7 +133,7 @@ extension Collection where Generator.Element: Comparable {
     ///
     /// - Returns: The index of `element`, or `nil` if `element` isn't
     ///   found.
-    func sortedIndex(of element: Generator.Element) -> Index?
+    func sortedIndex(of element: Iterator.Element) -> Index?
 
     /// Returns the range of elements equal to `element`, performing
     /// a binary search.
@@ -134,7 +144,16 @@ extension Collection where Generator.Element: Comparable {
     /// - Returns: The range of indices corresponding with elements
     ///   equal to `element`, or an empty range with its `startIndex`
     ///   equal to the insertion point for `element`.
-    func sortedRange(of element: Generator.Element) -> Range<Index>
+    func sortedRange(of element: Iterator.Element) -> Range<Index>
+}
+
+extension Sequence {
+    /// Returns `Optional(true)` if an element was found;
+    /// `Optional(false)` if an element was searched for but not found;
+    /// `nil` otherwise.
+    func _customContainsComparableElement(element: Iterator.Element) -> Bool?
+}
+```
 }
 ```
 

--- a/SE-0047.md
+++ b/SE-0047.md
@@ -154,6 +154,57 @@ extension Sequence {
     func _customContainsComparableElement(element: Iterator.Element) -> Bool?
 }
 ```
+
+## Example usage
+
+As an example of how the `partitionedIndex(of:)` method enables heterogenous binary search, this `SortedDictionary` type uses an array of `(Word, Definition)` tuples as its storage, sorted by `Word`.
+
+```swift
+struct SortedDictionary<Word: Comparable, Definition>:
+    Collection, DictionaryLiteralConvertible
+{
+    var _storage: [(word: Word, definition: Definition)]
+    
+    // Collection
+    var startIndex: Int { return _storage.startIndex }
+    var endIndex: Int { return _storage.endIndex }
+    subscript(index: Int) -> (word: Word, definition: Definition) {
+        return _storage[index]
+    }
+
+    // DictionaryLiteralConvertible
+    init(dictionaryLiteral elements: (Word, Definition)...) {
+        self._storage = elements
+            .sorted { $0.0 < $1.0 }
+            .map { (word: $0, definition: $1) }
+    }
+
+    // key/value access
+    subscript(word: Word) -> Definition? {
+        get {
+            let i = _storage.partitionedIndex(where: { $0.word < word })
+            if i != endIndex && _storage[i].word == word {
+                return _storage[i].definition
+            }
+            return nil
+        }
+        set {
+            // find insertion point
+            let i = _storage.partitionedIndex(where: { $0.word < word })
+            
+            if i != endIndex && _storage[i].word == word {
+                // update or delete
+                if let newValue = newValue {
+                    _storage[i].definition = newValue
+                } else {
+                    _storage.remove(at: i)
+                }
+            } else if let newValue = newValue {
+                // insert
+                _storage.insert((word, newValue), at: i)
+            }
+        }
+    }
 }
 ```
 

--- a/SE-0047.md
+++ b/SE-0047.md
@@ -163,6 +163,16 @@ The only change on code will be the availability of four (plus overloads) safer 
 
 Given the notorious difficulty for a programmer to implement binary search on their own, this proposal aims to simplify its use and thus reduce the amount of bugs in programs.
 
+### Removal of `partition()` / `partition(isOrderedBefore:)`
+
+The current `partition()` method is used by the standard library's current sorting algorithm, but doesn't offer the more general partitioning functionality of the proposed `partition(where:)` method. If this proposal is accepted without removing the existing methods, there would be three `partition` methods available:
+
+- `partition(isOrderedBefore:)`
+- `partition()` (an overload of `partition(isOrderedBefore:)` for `Comparable` elements)
+- `partition(where:)`
+
+A thorough, though not exhaustive, search of GitHub for uses of the existing `partition` method found no evidence. The results were primarily tests from the Swift project and third-party implementations of `partition` similar to the one proposed.
+
 ## Alternatives considered
 
 The authors considered a few alternatives to the current proposal:


### PR DESCRIPTION
This is the last revision, I promise!
- Fixes some incorrect syntax in the proposed APIs (e.g., `Generator` → `Iterator`)
- Adds two new APIs as customization points, `Sequence._customContainsComparableElement(_:)` and `Collection._customIndexOfComparableElement(_:)`
- Adds an example type that uses `partitionedIndex(where:)` to show how these proposed APIs are meeting the requested functionality
- Adds some justification for why I think the existing `partition` methods should go (do you all agree with this?)

Feedback? Questions? @j-haj @haravikk @lorenzoracca
